### PR TITLE
Do not crash if matplotlib Gtk backend fails

### DIFF
--- a/scape/plots_basic.py
+++ b/scape/plots_basic.py
@@ -7,7 +7,8 @@ import numpy as np
 try:
     import matplotlib as mpl
     import matplotlib.pyplot as plt
-except ImportError:
+# The Gtk backend wants to start plotting right away, hence the RuntimeError
+except (ImportError, RuntimeError):
     pass
 
 try:

--- a/scape/plots_canned.py
+++ b/scape/plots_canned.py
@@ -8,7 +8,8 @@ import numpy as np
 try:
     import matplotlib as mpl
     import matplotlib.pyplot as plt
-except ImportError:
+# The Gtk backend wants to start plotting right away, hence the RuntimeError
+except (ImportError, RuntimeError):
     pass
 
 from katpoint import rad2deg, Timestamp, construct_azel_target


### PR DESCRIPTION
Ignore the RuntimeError exception of the Gtk matplotlib backend if
an X11 display could not be opened. Import scape without plotting
functionality instead. This is useful because the Gtk backend tends
to be the default one on Linux, and Linux is frequently used for
remote testing and debugging of scape, without X11 forwarding too.

Reviewer: @LauraRichter 
