### PR TITLE
Fixes for v4 file format

### DIFF
--- a/scape/dataset.py
+++ b/scape/dataset.py
@@ -17,8 +17,8 @@ try:
 except ImportError:
     xdmfits_found = False
 try:
-    from .kathdf5 import load_dataset as hdf5_load
-    from .hdf5 import load_dataset as old_hdf5_load
+    from .katdal_dataset import load_dataset as katdal_load
+    from .hdf5 import load_dataset as hdf5_load
     from .hdf5 import save_dataset as hdf5_save
     hdf5_found = True
 except ImportError:
@@ -129,13 +129,13 @@ class DataSet(object):
                     raise ImportError('HDF5 support could not be loaded - please check hdf5 module')
                 if kwargs.get('katdal', True):
                     compscanlist, experiment_id, observer, description, data_unit, \
-                        corrconf, antenna, antenna2, nd_h_model, nd_v_model, enviro = hdf5_load(filename, **kwargs)
+                        corrconf, antenna, antenna2, nd_h_model, nd_v_model, enviro = katdal_load(filename, **kwargs)
                 else:
                     compscanlist, experiment_id, observer, description, data_unit, \
-                        corrconf, antenna, antenna2, nd_h_model, nd_v_model, enviro = old_hdf5_load(filename, **kwargs)
+                        corrconf, antenna, antenna2, nd_h_model, nd_v_model, enviro = hdf5_load(filename, **kwargs)
             elif ext == '.rdb':
                 compscanlist, experiment_id, observer, description, data_unit, \
-                    corrconf, antenna, antenna2, nd_h_model, nd_v_model, enviro = hdf5_load(filename, **kwargs)
+                    corrconf, antenna, antenna2, nd_h_model, nd_v_model, enviro = katdal_load(filename, **kwargs)
             else:
                 raise ValueError("File extension '%s' not understood" % ext)
 

--- a/scape/katdal_dataset.py
+++ b/scape/katdal_dataset.py
@@ -11,7 +11,7 @@ from .gaincal import NoiseDiodeModel
 from .scan import Scan, scape_pol_if
 from .compoundscan import CorrelatorConfig, CompoundScan
 
-logger = logging.getLogger("scape.kathdf5")
+logger = logging.getLogger("scape.katdal_dataset")
 
 # -------------------------------------------------------------------------------------------------
 # --- FUNCTION :  load_dataset


### PR DESCRIPTION
This has two main aims:
  - ensure that RDB files are loaded by `katdal` and not the old HDF5 loader (even supports URL-style query strings at the end of the filename), and
  - use the correct (az, el) sensor names.

For sanity, rename the katdal loader to just that (not the "HDF5" loader).

This addresses bugs uncovered in tickets MRTS-166, MRTS-167, MRTS-394 and MKAIV-1221.