### PR TITLE
Bugfix: plot_compound_scan_on_target() to plot scans having compscan …

### DIFF
--- a/scape/plots_canned.py
+++ b/scape/plots_canned.py
@@ -1101,8 +1101,9 @@ def plot_compound_scan_on_target(compscan, pol='absI', subtract_baseline=True, l
     # Extract total power and target coordinates (in degrees) of all scans (or those with baselines)
     if subtract_baseline:
         compscan_power = np.hstack([remove_spikes(np.abs(scan.pol(pol)[:, band]), spike_width=spike_width) -
-                                    scan.baseline(scan.timestamps) for scan in compscan.scans if scan.baseline])
-        target_coords = rad2deg(np.hstack([scan.target_coords for scan in compscan.scans if scan.baseline]))
+                                    (scan.baseline(scan.timestamps) if scan.baseline else compscan.baseline(scan.target_coords))
+                                    for scan in compscan.scans if (scan.baseline or compscan.baseline)])
+        target_coords = rad2deg(np.hstack([scan.target_coords for scan in compscan.scans if (scan.baseline or compscan.baseline)]))
     else:
         compscan_power = np.hstack([remove_spikes(np.abs(scan.pol(pol)[:, band]), spike_width=spike_width)
                                     for scan in compscan.scans])


### PR DESCRIPTION
…baselines

plot_compound_scan_on_target() used to "hide" scans that didn't have __scan__ baselines but did have __compscan__ baselines.
__compscan__ baselines are "valid" so i've changed the code to plot those scans just like for the others.

The "bug" had the following consequences which have now been resolved:
1. Users would believe that the "hidden" scans were also neglected in the beam fitting, which is an invalid inference.
2. The sizes of the circles would be normalized without the hidden scans, leading to distorted circle plots.