### PR TITLE
Make scape import in Python 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ katpoint
 numpy
 scipy
 scikits.fitting
+six

--- a/scape/dataset.py
+++ b/scape/dataset.py
@@ -2,8 +2,8 @@
 
 import os.path
 import logging
-import urlparse
 
+import six.moves.urllib.parse as urlparse
 import numpy as np
 import katpoint
 

--- a/scape/katdal_dataset.py
+++ b/scape/katdal_dataset.py
@@ -2,8 +2,8 @@
 
 import logging
 import os.path
-import urlparse
 
+import six.moves.urllib.parse as urlparse
 import numpy as np
 import katdal
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(name="scape",
           "numpy",
           "scipy",
           "katpoint",
-          "scikits.fitting"
+          "scikits.fitting",
+          "six"
       ],
       tests_require=[
           "nose",


### PR DESCRIPTION
It's not actually ported to Python 3, but this makes it importable for
the benefit of code that indirectly causes it to be imported but doesn't
actually use it.