### PR TITLE
SPR1-40: Fix Python 3, FITS and logging

### DIFF
--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -2,5 +2,5 @@ katdal
 acsm
 h5py
 matplotlib
-pyfits
+astropy
 setuptools

--- a/scape/__init__.py
+++ b/scape/__init__.py
@@ -42,8 +42,9 @@ if _module_found('matplotlib', 'Matplotlib was not found - plotting will be disa
                                plot_data_set_in_mount_space,  # noqa: F401
                                plot_measured_beam_pattern)  # noqa: F401
 
-# Check if pyfits is present, otherwise skip FITS creation routines
-if _module_found('pyfits', 'PyFITS was not found - FITS creation will be disabled'):
+# Check if astropy.io.fits is present, otherwise skip FITS creation routines
+if _module_found('astropy.io.fits',
+                 'astropy.io.fits was not found - FITS creation will be disabled'):
     from .plots_basic import save_fits_image  # noqa: F401
 
 # BEGIN VERSION CHECK

--- a/scape/__init__.py
+++ b/scape/__init__.py
@@ -1,19 +1,23 @@
 """The Single-dish Continuum Analysis PackagE."""
 
-import logging
-import sys
+import logging as _logging
 
 
-# Setup library logger, and suppress spurious logger messages via a null handler
-class _NullHandler(logging.Handler):
-    def emit(self, record):
-        pass
+# Setup library logger and add a print-like handler used when no logging is configured
+class _NoConfigFilter(_logging.Filter):
+    """Filter which only allows event if top-level logging is not configured."""
+
+    def filter(self, record):
+        return 1 if not _logging.root.handlers else 0
 
 
-_logger = logging.getLogger("scape")
-_logger.addHandler(_NullHandler())
-# Set up basic logging if it hasn't been done yet, in order to display error messages and such
-logging.basicConfig(level=logging.DEBUG, stream=sys.stdout, format="%(levelname)s: %(message)s")
+_no_config_handler = _logging.StreamHandler()
+_no_config_handler.setFormatter(_logging.Formatter(_logging.BASIC_FORMAT))
+_no_config_handler.addFilter(_NoConfigFilter())
+logger = _logging.getLogger(__name__)
+logger.addHandler(_no_config_handler)
+logger.setLevel(_logging.DEBUG)
+
 
 # Most operations are directed through the data set
 from .dataset import DataSet  # noqa: E402,F401
@@ -27,7 +31,7 @@ def _module_found(name, message):
         __import__(name)
         return True
     except ImportError:
-        _logger.warn(message)
+        logger.warn(message)
         return False
 
 
@@ -58,5 +62,3 @@ else:
     __version__ = _katversion.get_version(__path__[0])  # noqa: F821
 # END VERSION CHECK
 
-# Clean up module namespace to make it easier to spot the useful parts
-del logging, sys, _NullHandler, _module_found

--- a/scape/plots_basic.py
+++ b/scape/plots_basic.py
@@ -271,7 +271,8 @@ def plot_segments(x, y, z=None, labels=None, width=0.0, compact=True, add_breaks
         raise ValueError('Shape mismatch between x and y (segment lengths are %s vs %s)' %
                          ([np.shape(s)[0] for s in x], [np.shape(s)[0] for s in y]))
     if z is not None:
-        yx_shape = zip([np.shape(s)[0] for s in y], [np.shape(s)[0] for s in x])
+        yx_shape = list(zip([np.shape(s)[0] for s in y],
+                            [np.shape(s)[0] for s in x]))
         if [np.shape(s) for s in z] != yx_shape:
             raise ValueError('Shape mismatch between z and (y, x) (segment shapes are %s vs %s)' %
                              ([np.shape(s) for s in z], yx_shape))
@@ -330,7 +331,8 @@ def plot_segments(x, y, z=None, labels=None, width=0.0, compact=True, add_breaks
     if plot_type == 'line':
         if color is not None:
             kwargs['color'] = color
-        segments = mpl.collections.LineCollection([zip(xsegm, ysegm) for xsegm, ysegm in zip(x, y)], **kwargs)
+        segments_xy = [list(zip(xsegm, ysegm)) for xsegm, ysegm in zip(x, y)]
+        segments = mpl.collections.LineCollection(segments_xy, **kwargs)
         ax.add_collection(segments)
     elif plot_type == 'barv':
         x = np.hstack(x)

--- a/scape/plots_basic.py
+++ b/scape/plots_basic.py
@@ -12,7 +12,7 @@ except (ImportError, RuntimeError):
     pass
 
 try:
-    import pyfits
+    from astropy.io import fits
 except ImportError:
     pass
 
@@ -855,23 +855,23 @@ def save_fits_image(filename, x, y, Z, target_name='', coord_system='radec',
         world_per_pixel.append(1)
         Z = Z[np.newaxis]
 
-    phdu = pyfits.PrimaryHDU(Z)
+    phdu = fits.PrimaryHDU(Z)
     phdu.update_header()
-    phdu.header.update('DATE', create_date, comment='UT file creation time')
-    phdu.header.update('ORIGIN', 'SKA SA', 'institution that created file')
-    phdu.header.update('DATE-OBS', observe_date, comment='UT observation start time')
-    phdu.header.update('TELESCOP', telescope)
-    phdu.header.update('INSTRUME', instrument)
-    phdu.header.update('OBSERVER', observer)
-    phdu.header.update('OBJECT', target_name, comment='source name')
-    phdu.header.update('EQUINOX', 2000.0, comment='equinox of ra dec')
-    phdu.header.update('BUNIT', data_unit, comment='units of flux')
+    phdu.header.set('DATE', create_date, comment='UT file creation time')
+    phdu.header.set('ORIGIN', 'SKA SA', 'institution that created file')
+    phdu.header.set('DATE-OBS', observe_date, comment='UT observation start time')
+    phdu.header.set('TELESCOP', telescope)
+    phdu.header.set('INSTRUME', instrument)
+    phdu.header.set('OBSERVER', observer)
+    phdu.header.set('OBJECT', target_name, comment='source name')
+    phdu.header.set('EQUINOX', 2000.0, comment='equinox of ra dec')
+    phdu.header.set('BUNIT', data_unit, comment='units of flux')
     for n, (ax_type, ref_pix, ref_val, ref_delt) in enumerate(zip(axes, ref_pixel, ref_world, world_per_pixel)):
-        phdu.header.update('CTYPE%d' % (n + 1), ax_type)
-        phdu.header.update('CRPIX%d' % (n + 1), ref_pix)
-        phdu.header.update('CRVAL%d' % (n + 1), ref_val)
-        phdu.header.update('CDELT%d' % (n + 1), ref_delt)
-        phdu.header.update('CROTA%d' % (n + 1), 0)
-    phdu.header.update('DATAMAX', Z.max(), comment='max pixel value')
-    phdu.header.update('DATAMIN', Z.min(), comment='min pixel value')
-    pyfits.writeto(filename, phdu.data, phdu.header, clobber=clobber)
+        phdu.header.set('CTYPE%d' % (n + 1), ax_type)
+        phdu.header.set('CRPIX%d' % (n + 1), ref_pix)
+        phdu.header.set('CRVAL%d' % (n + 1), ref_val)
+        phdu.header.set('CDELT%d' % (n + 1), ref_delt)
+        phdu.header.set('CROTA%d' % (n + 1), 0)
+    phdu.header.set('DATAMAX', Z.max(), comment='max pixel value')
+    phdu.header.set('DATAMIN', Z.min(), comment='min pixel value')
+    fits.writeto(filename, phdu.data, phdu.header, overwrite=clobber)

--- a/scape/xdmfits.py
+++ b/scape/xdmfits.py
@@ -16,7 +16,7 @@ import cPickle as pickle
 import re
 import os.path
 
-import pyfits
+from astropy.io import fits
 import numpy as np
 from katpoint import deg2rad, rad2deg, Target, Antenna, Catalogue
 
@@ -167,7 +167,7 @@ def load_xdm_noise_models(filename, feed_id=None):
     """
     # Open FITS file
     try:
-        hdu = pyfits.open(filename)
+        hdu = fits.open(filename)
     except (IOError, TypeError):
         msg = 'The FITS file (%s) cannot be read!' % filename
         logger.error(msg)
@@ -246,10 +246,10 @@ def load_scan(filename):
         If file would not open or is not a proper FITS file
 
     """
-    hdu = pyfits.open(filename)
+    hdu = fits.open(filename)
     try:
         hdu.verify(option='exception')
-    except pyfits.VerifyError:
+    except fits.VerifyError:
         hdu.close()
         raise IOError("File '%s' does not comply with FITS standard" % filename)
     header = hdu['PRIMARY'].header


### PR DESCRIPTION
- Convert Python 3 zip objects to lists to make `plot_xyz` work.
- Replace PyFITS with astropy.io.fits to make warning go away.
- Get rid of ancient PyFITS Header API in the process.
- Replace naughty `logging.basicConfig` with katdal's trick.
