### PR TITLE
SPR1-2871: Fix deprecation issues

### DIFF
--- a/scape/__init__.py
+++ b/scape/__init__.py
@@ -31,7 +31,7 @@ def _module_found(name, message):
         __import__(name)
         return True
     except ImportError:
-        logger.warn(message)
+        logger.warning(message)
         return False
 
 

--- a/scape/dataset.py
+++ b/scape/dataset.py
@@ -519,7 +519,7 @@ class DataSet(object):
                 scan.pointing = view.view(scan.pointing.dtype).squeeze()
                 # All flags in a window are OR'ed together to form the 'average'
                 num_fields = len(scan.flags.dtype.names)
-                view = scan.flags.view(dtype=np.bool).reshape((num_samples, num_fields))
+                view = scan.flags.view(dtype=bool).reshape((num_samples, num_fields))
                 view = (view[:cutoff, :].reshape((new_len, window, num_fields)).sum(axis=1) > 0)
                 scan.flags = view.view(scan.flags.dtype).squeeze()
                 if scan.target_coords is not None:

--- a/scape/stats.py
+++ b/scape/stats.py
@@ -297,7 +297,7 @@ def chi2_conf_interval(dof, mean=1.0, sigma=3.0):
     if not np.isscalar(sigma):
         sigma = np.atleast_1d(np.asarray(sigma))
     # Ensure degrees of freedom is positive integer >= 1
-    dof = np.array(np.clip(np.floor(dof), 1.0, np.inf), dtype=np.int)
+    dof = np.array(np.clip(np.floor(dof), 1.0, np.inf), dtype=int)
     chi2_rv = stats.chi2(dof)
     normal_rv = stats.norm()
     # Translate normal conf interval to chi^2 distribution, maintaining the probability inside interval

--- a/scape/test/test_gaincal.py
+++ b/scape/test/test_gaincal.py
@@ -3,7 +3,7 @@
 
 import unittest
 import numpy as np
-import StringIO
+from io import StringIO
 
 from scape import gaincal
 
@@ -24,7 +24,7 @@ class NoiseDiodeModelTestCases(unittest.TestCase):
 # freq [Hz], T_nd [K]
 """
         self.file_data += '\n'.join(['%d, %.3f' % row for row in zip(self.freq, self.temp)])
-        self.csv_file = StringIO.StringIO(self.file_data)
+        self.csv_file = StringIO(self.file_data)
 
     def test_load_nd_model(self):
         nd = gaincal.NoiseDiodeModel(self.csv_file)

--- a/scape/xdmfits.py
+++ b/scape/xdmfits.py
@@ -277,7 +277,7 @@ def load_scan(filename):
                                  names=['az', 'el', 'rot'])
     # Move timestamps and pointing from start of each sample to the middle
     timestamps, pointing = move_start_to_center(timestamps, pointing, sample_period)
-    flags = np.rec.fromarrays([hdu['MSDATA'].data.field(s).astype(np.bool)
+    flags = np.rec.fromarrays([hdu['MSDATA'].data.field(s).astype(bool)
                                for s in ['Valid_F', 'ND_ON_F', 'RX_ON_F']],
                               names=['valid', 'nd_on', 'rx_on'])
     # The environmental variables are sampled when the FITS file is written to disk,


### PR DESCRIPTION
The following things are deprecated:

- `np.bool` and `np.int` (broken since numpy 1.24)  [use `bool` and `int`]
- `logger.warn`  [use `logger.warning`]
- `StringIO.StringIO`   [use `io.StringIO`]
